### PR TITLE
enable extended math parsing

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -2,6 +2,9 @@ title: Python Sandpit
 author: Thomas J. Sargent
 logo: _static/qe-logo-large.png
 
+parse:
+  myst_extended_syntax: true
+
 execute:
   execute_notebooks: "cache"
   timeout: 3600
@@ -17,3 +20,4 @@ sphinx:
     html_theme_options:
       header_organisation_url: https://quantecon.org
       header_organisation: QuantEcon
+    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
@thomassargent30 This enables extended parsing of math and the use of `\begin{align}` in text

https://jupyterbook.org/content/math.html#math-blocks
