### PR TITLE
[FIG] Enable label for code driven figures

### DIFF
--- a/lectures/five_preferences.md
+++ b/lectures/five_preferences.md
@@ -381,12 +381,21 @@ for i in range(π_hat_0_vals.size):  # Loop over all possible values for `π_hat
 ```
 
 ```{code-cell} ipython3
+---
+render:
+  figure:
+    caption: |
+      A Cool Figure
+    name: figure2-1
+---
 plt.figure(figsize=(5, 3))
 plt.plot(π_hat_0_vals, ent_vals, color='blue');
 plt.ylabel(r'entropy ($\pi_{1}=%.2f$)' % π[0] );
 plt.xlabel(r'$\hat{\pi}_1$');
 plt.show()
 ```
+
+This is a reference to {ref}`figure2-1`
 
 ```{code-cell} ipython3
 # Use same grid for `π_0_vals` as for `π_hat_0_vals` 


### PR DESCRIPTION
This enables figure's that are generated by code to be referenced

<img width="870" alt="Screen Shot 2021-05-28 at 2 05 42 pm" src="https://user-images.githubusercontent.com/8263752/119927917-caf96c00-bfbd-11eb-8cef-8ae8c849c882.png">

However there is currently a limitation in that a `caption` must be specified